### PR TITLE
Add outputs to the module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.0
+
+### Features
+
+* Add `id` and `slug` output variables.
+
 # [1.3.0](https://github.com/innovationnorway/terraform-github-team/compare/v1.2.0...v1.3.0) (2019-02-25)
 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ module "terraform_team" {
 | `parent_team` | `string` | The `slug` of a team to set as the parent team.                                                                                                                                                                                     |
 | `maintainers` | `list`   | The `login`s of organization members to add as maintainers of the team.                                                                                                                                                             |
 | `members`     | `list`   | The `login`s of organization members to add as normal members of the team.                                                                                                                                                          |
+## Module outputs
+
+Available outputs are listed below, along with their description
+| output | description |
+|---|---|
+|`id`| The ID of the created team. |
+|`slug`|  The slug of the created team, which may or may not differ from name, depending on whether name contains "URL-unsafe" characters. |
+
 ## Limitations
 
-Due to current limitations of the Terraform language, items added or removed from the `maintainers` and `members` lists, will also update subsequent items with indexes greater than where the addition or removal was made. 
+Due to current limitations of the Terraform language, items added or removed from the `maintainers` and `members` lists, will also update subsequent items with indexes greater than where the addition or removal was made.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = "${github_team.main.id}"
+}
+
+output "slug" {
+  value = "${github_team.main.slug}"
+}


### PR DESCRIPTION
Adds the `id` and the `slug` output to the module to allow users to
reference their values.